### PR TITLE
feat: add wrapper function for create tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ export default class Home extends Vue {
 ```typescript
 // user.spec.ts
 import { testStore } from 'vuex-typed-modules';
+import { createLocalVue } from '@vue/test-utils';
 // import state, actions, mutations and getters from some store module
 
 const configStore = {
@@ -295,6 +296,9 @@ const configStore = {
 	mutations,
 	getters
 };
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
 const store = testStore(configStore);
 

--- a/README.md
+++ b/README.md
@@ -281,3 +281,30 @@ export default class Home extends Vue {
   }
 }
 ```
+
+# Tests
+
+```typescript
+// user.spec.ts
+import { testStore } from 'vuex-typed-modules';
+// import state, actions, mutations and getters from your store module
+
+const configStore = {
+	state,
+	actions,
+	mutations,
+	getters
+};
+
+const store = testStore(configStore);
+
+describe('User Module', () => {
+	it('name should be empty', () => {
+		expect(store.state.name).toBe('');
+	});
+	it('name should change to Foo', () => {
+	    store.dispatch('CHANGE_NAME', 'Foo');
+		expect(store.state.name).toBe('Foo');
+	});
+});
+```

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ export default class Home extends Vue {
 ```typescript
 // user.spec.ts
 import { testStore } from 'vuex-typed-modules';
-// import state, actions, mutations and getters from your store module
+// import state, actions, mutations and getters from some store module
 
 const configStore = {
 	state,

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ export default class Home extends Vue {
 
 ```typescript
 // user.spec.ts
-import { testStore } from 'vuex-typed-modules';
+import { createTestStore } from 'vuex-typed-modules';
 import { createLocalVue } from '@vue/test-utils';
 // import state, actions, mutations and getters from some store module
 
@@ -300,7 +300,7 @@ const configStore = {
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-const store = testStore(configStore);
+const store = createTestStore(configStore);
 
 describe('User Module', () => {
 	it('name should be empty', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Database } from './database';
-export { testStore } from './tests'
+export { createTestStore } from './tests'
 export { VuexModule, VuexModuleArgs, createVuexModule } from './modules/default';
 export { VuexModuleHook } from './modules/hooks';
 export { VuexDynamicModule, ModuleToInstance, createVuexDynamicModule } from './modules/dynamic';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { Database } from './database';
+export { testStore } from './tests'
 export { VuexModule, VuexModuleArgs, createVuexModule } from './modules/default';
 export { VuexModuleHook } from './modules/hooks';
 export { VuexDynamicModule, ModuleToInstance, createVuexDynamicModule } from './modules/dynamic';

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -8,13 +8,13 @@ type GenerateTypedStoreReturn<T extends StoreDefaults> = Omit<
 > & {
   commit<K extends keyof T['mutations'], P extends Parameters<T['mutations'][K]>[1]>(
     key: K,
-    payload: P,
+    payload?: P,
     options?: CommitOptions
   ): ReturnType<T['mutations'][K]>;
 } & {
   dispatch<K extends keyof T['actions']>(
     key: K,
-    payload: Parameters<T['actions'][K]>[1],
+    payload?: Parameters<T['actions'][K]>[1],
     options?: DispatchOptions
   ): ReturnType<T['actions'][K]>;
 } & {

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,0 +1,31 @@
+import Vuex, { CommitOptions, DispatchOptions, Store } from 'vuex';
+
+type StoreDefaults = { mutations: any; getters: any; state: any; actions: any };
+
+type GenerateTypedStoreReturn<T extends StoreDefaults> = Omit<
+  Store<T['state']>,
+  'getters' | 'commit' | 'dispatch'
+> & {
+  commit<K extends keyof T['mutations'], P extends Parameters<T['mutations'][K]>[1]>(
+    key: K,
+    payload: P,
+    options?: CommitOptions
+  ): ReturnType<T['mutations'][K]>;
+} & {
+  dispatch<K extends keyof T['actions']>(
+    key: K,
+    payload: Parameters<T['actions'][K]>[1],
+    options?: DispatchOptions
+  ): ReturnType<T['actions'][K]>;
+} & {
+  getters: {
+    [K in keyof T['getters']]: ReturnType<T['getters'][K]>;
+  };
+};
+
+const testStore = <T extends StoreDefaults>(options: T): GenerateTypedStoreReturn<T> =>
+  new Vuex.Store({
+    ...options,
+  }) as unknown as GenerateTypedStoreReturn<T>;
+
+export { testStore };

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -23,9 +23,9 @@ type GenerateTypedStoreReturn<T extends StoreDefaults> = Omit<
   };
 };
 
-const testStore = <T extends StoreDefaults>(options: T): GenerateTypedStoreReturn<T> =>
+const createTestStore = <T extends StoreDefaults>(options: T): GenerateTypedStoreReturn<T> =>
   new Vuex.Store({
     ...options,
   }) as unknown as GenerateTypedStoreReturn<T>;
 
-export { testStore };
+export { createTestStore };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 export { Database } from './database';
-export { testStore } from './tests';
+export { createTestStore } from './tests';
 export { VuexModule, VuexModuleArgs, createVuexModule } from './modules/default';
 export { VuexModuleHook } from './modules/hooks';
 export { VuexDynamicModule, ModuleToInstance, createVuexDynamicModule } from './modules/dynamic';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 export { Database } from './database';
+export { testStore } from './tests';
 export { VuexModule, VuexModuleArgs, createVuexModule } from './modules/default';
 export { VuexModuleHook } from './modules/hooks';
 export { VuexDynamicModule, ModuleToInstance, createVuexDynamicModule } from './modules/dynamic';

--- a/types/tests.d.ts
+++ b/types/tests.d.ts
@@ -6,9 +6,9 @@ declare type StoreDefaults = {
     actions: any;
 };
 declare type GenerateTypedStoreReturn<T extends StoreDefaults> = Omit<Store<T['state']>, 'getters' | 'commit' | 'dispatch'> & {
-    commit<K extends keyof T['mutations'], P extends Parameters<T['mutations'][K]>[1]>(key: K, payload: P, options?: CommitOptions): ReturnType<T['mutations'][K]>;
+    commit<K extends keyof T['mutations'], P extends Parameters<T['mutations'][K]>[1]>(key: K, payload?: P, options?: CommitOptions): ReturnType<T['mutations'][K]>;
 } & {
-    dispatch<K extends keyof T['actions']>(key: K, payload: Parameters<T['actions'][K]>[1], options?: DispatchOptions): ReturnType<T['actions'][K]>;
+    dispatch<K extends keyof T['actions']>(key: K, payload?: Parameters<T['actions'][K]>[1], options?: DispatchOptions): ReturnType<T['actions'][K]>;
 } & {
     getters: {
         [K in keyof T['getters']]: ReturnType<T['getters'][K]>;

--- a/types/tests.d.ts
+++ b/types/tests.d.ts
@@ -14,5 +14,5 @@ declare type GenerateTypedStoreReturn<T extends StoreDefaults> = Omit<Store<T['s
         [K in keyof T['getters']]: ReturnType<T['getters'][K]>;
     };
 };
-declare const testStore: <T extends StoreDefaults>(options: T) => GenerateTypedStoreReturn<T>;
-export { testStore };
+declare const createTestStore: <T extends StoreDefaults>(options: T) => GenerateTypedStoreReturn<T>;
+export { createTestStore };

--- a/types/tests.d.ts
+++ b/types/tests.d.ts
@@ -1,0 +1,18 @@
+import { CommitOptions, DispatchOptions, Store } from 'vuex';
+declare type StoreDefaults = {
+    mutations: any;
+    getters: any;
+    state: any;
+    actions: any;
+};
+declare type GenerateTypedStoreReturn<T extends StoreDefaults> = Omit<Store<T['state']>, 'getters' | 'commit' | 'dispatch'> & {
+    commit<K extends keyof T['mutations'], P extends Parameters<T['mutations'][K]>[1]>(key: K, payload: P, options?: CommitOptions): ReturnType<T['mutations'][K]>;
+} & {
+    dispatch<K extends keyof T['actions']>(key: K, payload: Parameters<T['actions'][K]>[1], options?: DispatchOptions): ReturnType<T['actions'][K]>;
+} & {
+    getters: {
+        [K in keyof T['getters']]: ReturnType<T['getters'][K]>;
+    };
+};
+declare const testStore: <T extends StoreDefaults>(options: T) => GenerateTypedStoreReturn<T>;
+export { testStore };


### PR DESCRIPTION
Add a wrapper function for create tests.

Usage example:

```typescript
// user.spec.ts
import { createTestStore } from 'vuex-typed-modules';
import { createLocalVue } from '@vue/test-utils';
import Vuex from 'vuex';
// import state, actions, mutations and getters from some store module

const localVue = createLocalVue();
localVue.use(Vuex);

const configStore = {
    state,
    actions,
    mutations,
    getters
};

const store = createTestStore(configStore);

describe('User Module', () => {
    it('name should be empty', () => {
        expect(store.state.name).toBe('');
    });
    it('name should change to Foo', () => {
        store.dispatch('CHANGE_NAME', 'Foo');
	expect(store.state.name).toBe('Foo');
    });
});
```