### PR TITLE
Add support for Vue 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,14 @@
     "vue": "^2.0.0 || >=3.0.0-rc.0",
     "vuex": "^3.0.0 || >=4.0.0"
   },
+  "peerDependenciesMeta": {
+    "@nuxtjs/composition-api": {
+      "optional": true
+    },
+    "@vue/composition-api": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@nuxtjs/composition-api": "^0.24.7",
     "@types/lodash": "^4.14.171",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "typescript": "^4.3.5",
-    "vue-demi": "^0.10.1"
+    "vue-demi": "^0.13.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This project works fine with Vue 2.7, but its dependencies configuration causes `npm install` to fail because `composition-api` does not accept Vur 2.7 as it's already built in.

Solution is to mark `composition-api` dependencies as optional